### PR TITLE
Use specific lager dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- erlang -*-
 %% Config file for netlink-application
-{deps, [{lager, ".*"}]}.
+{deps, [{lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"2.0.3"}}}]}.
 {erl_opts, [debug_info, fail_on_warning]}.
 
 {port_env, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- erlang -*-
 %% Config file for netlink-application
-{deps, [{lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"2.0.3"}}}]}.
+{deps, [{lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"3.0.2"}}}]}.
 {erl_opts, [debug_info, fail_on_warning]}.
 
 {port_env, [


### PR DESCRIPTION
The previous dependency definition used an undocumented feature of rebar that is not compatible with other build tools such as the future rebar3 or elixir's mix.

By specifying the dependency like in this PR we will be compatible with both rebar3 and mix.
