### PR TITLE
Introduce rebar3 support and keep compatibility with rebar2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- erlang -*-
 %% Config file for netlink-application
-{deps, [{lager, ".*", {git, "git://github.com/basho/lager.git", {tag,"3.0.2"}}}]}.
+{deps, [{lager, "3.2.1"}]}.
 {erl_opts, [debug_info, fail_on_warning]}.
 
 {port_env, [
@@ -10,3 +10,14 @@
 {port_specs, [
 	      {"(linux)","priv/netlink_drv.so",["c_src/*.c"]}
 	     ]}.
+
+{plugins, [
+    pc
+]}.
+
+{provider_hooks, [
+    {pre, [
+        {compile, {pc, compile}},
+        {clean, {pc, clean}}
+    ]}
+]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,10 @@
+case erlang:function_exported(rebar3, main, 1) of
+    true -> % rebar3
+        CONFIG;
+    false -> % rebar 2.x or older
+        %% Rebuild deps, possibly including those that have been moved to
+        %% profiles
+        [{deps, [
+            {lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "3.2.1"}}}
+         ]} | [Config || {Key, _Value}=Config <- CONFIG, Key =/= deps andalso Key =/= plugins]]
+end.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+{"1.1.0",
+[{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.8">>},1},
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.2.1">>},0}]}.
+[
+{pkg_hash,[
+ {<<"goldrush">>, <<"2024BA375CEEA47E27EA70E14D2C483B2D8610101B4E852EF7F89163CDB6E649">>},
+ {<<"lager">>, <<"EEF4E18B39E4195D37606D9088EA05BF1B745986CF8EC84F01D332456FE88D17">>}]}
+].


### PR DESCRIPTION
Following the guide and example from https://github.com/blt/port_compiler#example I've implemented support for `rebar3` while keeping compatibility with `rebar2`. `lager` was updated to the latest available version found on `hex.pm`.
